### PR TITLE
Update config doc block

### DIFF
--- a/config/laravel-slack.php
+++ b/config/laravel-slack.php
@@ -41,7 +41,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Application Name
+    | Application Image
     |--------------------------------------------------------------------------
     |
     | The user image that is used for messages from this integration.


### PR DESCRIPTION
This PR updates the doc block of the config file. It fixes an issue where the `application_image` key was referenced as `Application Name` instead of `Application Image`.