### PR TITLE
Add Lumen support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=7.0.0",
         "guzzlehttp/guzzle": "^6.3",
         "illuminate/notifications": "^5.5",
-        "illuminate/support": "^5.5"
+        "illuminate/support": "^5.5",
+        "ramsey/uuid": "^3.8"
     },
     "require-dev": {
         "orchestra/testbench": "~3.5",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "php": ">=7.0.0",
         "guzzlehttp/guzzle": "^6.3",
         "illuminate/notifications": "^5.5",
-        "illuminate/support": "^5.5",
-        "ramsey/uuid": "^3.8"
+        "illuminate/support": "^5.5"
     },
     "require-dev": {
         "orchestra/testbench": "~3.5",

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -3,6 +3,7 @@
 namespace Pressutto\LaravelSlack;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Pressutto\LaravelSlack\Notifications\SimpleSlack;
@@ -36,7 +37,7 @@ class Slack
 
     public function __construct(array $config)
     {
-        $this->anonymousNotifiable = \Notification::route('slack', $config['slack_webhook_url']);
+        $this->anonymousNotifiable = Notification::route('slack', $config['slack_webhook_url']);
         $this->recipients = [$config['default_channel']];
         $this->from = $config['application_name'];
         $this->image = $config['application_image'];


### PR DESCRIPTION
I found that I could get this to work within Lumen (5.7.*) by requiring Ramsey's UUID package and ensuring that the constructor of the Slack class utilises the Notification facade

This has not been regression tested in Laravel yet.