### PR TITLE
Allow user specify webhook for instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ class User extends Model
 \Slack::to(User::where('verified', true))->send('Sending message to all verified users!');
 ```
 
+- Send message by specifying webhook:
+
+```php
+\Slack::to('#finance')->webhook('https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX')->send('Hey, finance channel! A new order was created just now!');
+```
+
 - And more...
 
     This package is both under development and underdeveloped.

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "php": ">=7.0.0",
         "guzzlehttp/guzzle": "^6.3",
         "illuminate/notifications": "^5.5",
-        "illuminate/support": "^5.5",
-        "squizlabs/php_codesniffer": "^3.5"
+        "illuminate/support": "^5.5"
     },
     "require-dev": {
         "orchestra/testbench": "~3.5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=7.0.0",
         "guzzlehttp/guzzle": "^6.3",
         "illuminate/notifications": "^5.5",
-        "illuminate/support": "^5.5"
+        "illuminate/support": "^5.5",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "require-dev": {
         "orchestra/testbench": "~3.5",

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -35,18 +35,17 @@ class Slack
      */
     private $config;
 
-    public function __construct( array $config = [] )
+    public function __construct(array $config = [])
     {
         $config = $this->mergeConfig($config);
         $this->anonymousNotifiable = Notification::route('slack', $config['slack_webhook_url']);
-        $this->recipients          = [ $config['default_channel'] ];
-        $this->from                = $config['application_name'];
-        $this->image               = $config['application_image'];
-        $this->config              = $config;
+        $this->recipients = [ $config['default_channel'] ];
+        $this->from = $config['application_name'];
+        $this->image = $config['application_image'];
+        $this->config = $config;
     }
 
     /**
-     * 
      * Use config variables specified by user
      * use default variables when not specified
      *
@@ -58,9 +57,9 @@ class Slack
     {
         $defaultConfig = config('laravel-slack');
 
-        foreach ( $defaultConfig as $key => $value ) {
-            if (! array_key_exists($key, $config) ) {
-                $config[ $key ] = $value;
+        foreach ($defaultConfig as $key => $value) {
+            if (! array_key_exists($key, $config)) {
+                $config[$key] = $value;
             }
         }
 
@@ -68,9 +67,8 @@ class Slack
     }
 
     /**
-     * 
      * Allows user specify webhook to use
-     * for current instance
+     * for current instance.
      *
      * @param string $url
      *

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -35,51 +35,57 @@ class Slack
      */
     private $config;
 
-	public function __construct( array $config = [] )
-	{
-		$config = $this->mergeConfig($config);
-		$this->anonymousNotifiable = Notification::route( 'slack', $config['slack_webhook_url'] );
-		$this->recipients          = [ $config['default_channel'] ];
-		$this->from                = $config['application_name'];
-		$this->image               = $config['application_image'];
-		$this->config              = $config;
-	}
+    public function __construct( array $config = [] )
+    {
+        $config = $this->mergeConfig($config);
+        $this->anonymousNotifiable = Notification::route('slack', $config['slack_webhook_url']);
+        $this->recipients          = [ $config['default_channel'] ];
+        $this->from                = $config['application_name'];
+        $this->image               = $config['application_image'];
+        $this->config              = $config;
+    }
 
-	/**Use config variables specified by user
-	 * use default variables when not specified
-	 * @param $config
-	 *
-	 * @return mixed
-	 */
-	private function mergeConfig(array $config) : array
-	{
-		$defaultConfig = config( 'laravel-slack' );
+    /**
+     * 
+     * Use config variables specified by user
+     * use default variables when not specified
+     *
+     * @param $config
+     *
+     * @return mixed
+     */
+    private function mergeConfig(array $config) : array
+    {
+        $defaultConfig = config('laravel-slack');
 
-		foreach ( $defaultConfig as $key => $value ) {
-			if ( ! array_key_exists( $key, $config ) ) {
-				$config[ $key ] = $value;
-			}
-		}
+        foreach ( $defaultConfig as $key => $value ) {
+            if (! array_key_exists($key, $config) ) {
+                $config[ $key ] = $value;
+            }
+        }
 
-		return $config;
-	}
+        return $config;
+    }
 
-	/**Allows user specify webhook to use
-	 * for current instance
-	 * @param string $url
-	 *
-	 * @return $this
-	 */
-	public function webhook(string $url) : self
-	{
-		$this->anonymousNotifiable = Notification::route( 'slack', $url );
-		return $this;
-	}
+    /**
+     * 
+     * Allows user specify webhook to use
+     * for current instance
+     *
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function webhook(string $url) : self
+    {
+        $this->anonymousNotifiable = Notification::route('slack', $url);
+        return $this;
+    }
 
     /**
      * Set the recipients of the message.
      *
-     * @param  object|array|string $recipient
+     * @param object|array|string $recipient
      *
      * @return $this
      */
@@ -91,13 +97,15 @@ class Slack
 
         $recipients = is_array($recipient) ? $recipient : func_get_args();
 
-        $this->recipients = array_map(function ($recipient) {
-            if (is_object($recipient)) {
-                return $recipient->slack_channel;
-            }
+        $this->recipients = array_map(
+            function ($recipient) {
+                if (is_object($recipient)) {
+                    return $recipient->slack_channel;
+                }
 
-            return $recipient;
-        }, $recipients);
+                return $recipient;
+            }, $recipients
+        );
 
         return $this;
     }

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -52,7 +52,7 @@ class Slack
      *
      * @return $this
      */
-    public function webhook(string $url) : self
+    public function webhook(string $url): self
     {
         $this->anonymousNotifiable = Notification::route('slack', $url);
 

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -35,35 +35,13 @@ class Slack
      */
     private $config;
 
-    public function __construct(array $config = [])
+    public function __construct(array $config)
     {
-        $config = $this->mergeConfig($config);
         $this->anonymousNotifiable = Notification::route('slack', $config['slack_webhook_url']);
         $this->recipients = [$config['default_channel']];
         $this->from = $config['application_name'];
         $this->image = $config['application_image'];
         $this->config = $config;
-    }
-
-    /**
-     * Use config variables specified by user
-     * use default variables when not specified.
-     *
-     * @param $config
-     *
-     * @return mixed
-     */
-    private function mergeConfig(array $config) : array
-    {
-        $defaultConfig = config('laravel-slack');
-
-        foreach ($defaultConfig as $key => $value) {
-            if (! array_key_exists($key, $config)) {
-                $config[$key] = $value;
-            }
-        }
-
-        return $config;
     }
 
     /**

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -35,7 +35,8 @@ class Slack
      */
     private $config;
 
-	public function __construct( array $config = [] ) {
+	public function __construct( array $config = [] )
+	{
 		$config = $this->mergeConfig($config);
 		$this->anonymousNotifiable = Notification::route( 'slack', $config['slack_webhook_url'] );
 		$this->recipients          = [ $config['default_channel'] ];
@@ -50,7 +51,8 @@ class Slack
 	 *
 	 * @return mixed
 	 */
-	private function mergeConfig($config) {
+	private function mergeConfig(array $config) : array
+	{
 		$defaultConfig = config( 'laravel-slack' );
 
 		foreach ( $defaultConfig as $key => $value ) {
@@ -68,7 +70,8 @@ class Slack
 	 *
 	 * @return $this
 	 */
-	public function webhook(string $url) {
+	public function webhook(string $url) : self
+	{
 		$this->anonymousNotifiable = Notification::route( 'slack', $url );
 		return $this;
 	}

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -35,14 +35,43 @@ class Slack
      */
     private $config;
 
-    public function __construct(array $config)
-    {
-        $this->anonymousNotifiable = Notification::route('slack', $config['slack_webhook_url']);
-        $this->recipients = [$config['default_channel']];
-        $this->from = $config['application_name'];
-        $this->image = $config['application_image'];
-        $this->config = $config;
-    }
+	public function __construct( array $config = [] ) {
+		$config = $this->mergeConfig($config);
+		$this->anonymousNotifiable = Notification::route( 'slack', $config['slack_webhook_url'] );
+		$this->recipients          = [ $config['default_channel'] ];
+		$this->from                = $config['application_name'];
+		$this->image               = $config['application_image'];
+		$this->config              = $config;
+	}
+
+	/**Use config variables specified by user
+	 * use default variables when not specified
+	 * @param $config
+	 *
+	 * @return mixed
+	 */
+	private function mergeConfig($config) {
+		$defaultConfig = config( 'laravel-slack' );
+
+		foreach ( $defaultConfig as $key => $value ) {
+			if ( ! array_key_exists( $key, $config ) ) {
+				$config[ $key ] = $value;
+			}
+		}
+
+		return $config;
+	}
+
+	/**Allows user specify webhook to use
+	 * for current instance
+	 * @param string $url
+	 *
+	 * @return $this
+	 */
+	public function webhook(string $url) {
+		$this->anonymousNotifiable = Notification::route( 'slack', $url );
+		return $this;
+	}
 
     /**
      * Set the recipients of the message.

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -39,7 +39,7 @@ class Slack
     {
         $config = $this->mergeConfig($config);
         $this->anonymousNotifiable = Notification::route('slack', $config['slack_webhook_url']);
-        $this->recipients = [ $config['default_channel'] ];
+        $this->recipients = [$config['default_channel']];
         $this->from = $config['application_name'];
         $this->image = $config['application_image'];
         $this->config = $config;
@@ -47,7 +47,7 @@ class Slack
 
     /**
      * Use config variables specified by user
-     * use default variables when not specified
+     * use default variables when not specified.
      *
      * @param $config
      *
@@ -77,6 +77,7 @@ class Slack
     public function webhook(string $url) : self
     {
         $this->anonymousNotifiable = Notification::route('slack', $url);
+
         return $this;
     }
 

--- a/tests/SendMessageTest.php
+++ b/tests/SendMessageTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Pressutto\LaravelSlack\Slack;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Messages\SlackMessage;

--- a/tests/SendMessageTest.php
+++ b/tests/SendMessageTest.php
@@ -37,17 +37,12 @@ class SendMessageTest extends TestCase
     public function testSendMessageToAUserWithSpecifiedConfig()
     {
         $notification = Notification::fake();
-        $config = [
-        'slack_webhook_url' => 'https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX',
-        ];
 
-        $slack = new Slack($config);
-
-        $slack->to('#random')->send('RANDOM');
+        \Pressutto\LaravelSlack\Facades\Slack::to('#fashion')->webhook('https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX')->send('RANDOM');
 
         $notification->assertSentTo(new AnonymousNotifiable(), SimpleSlack::class, 1);
         $slackMessageSent = $notification->sent(new AnonymousNotifiable(), SimpleSlack::class)->first()->toSlack();
-        $this->assertEquals('#random', $slackMessageSent->channel);
+        $this->assertEquals('#fashion', $slackMessageSent->channel);
         $this->assertEquals('RANDOM', $slackMessageSent->content);
     }
 

--- a/tests/SendMessageTest.php
+++ b/tests/SendMessageTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
+use Pressutto\LaravelSlack\Slack;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Pressutto\LaravelSlack\Notifications\SimpleSlack;
-use Pressutto\LaravelSlack\Slack;
 
 class SendMessageTest extends TestCase
 {
@@ -37,9 +37,9 @@ class SendMessageTest extends TestCase
     public function testSendMessageToAUserWithSpecifiedConfig()
     {
         $notification = Notification::fake();
-        $config = array(
-        'slack_webhook_url' => 'https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX'
-        );
+        $config = [
+        'slack_webhook_url' => 'https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX',
+        ];
 
         $slack = new Slack($config);
 

--- a/tests/SendMessageTest.php
+++ b/tests/SendMessageTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Notification;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Pressutto\LaravelSlack\Notifications\SimpleSlack;
+use Pressutto\LaravelSlack\Slack;
 
 class SendMessageTest extends TestCase
 {
@@ -14,6 +15,35 @@ class SendMessageTest extends TestCase
         $notification = Notification::fake();
 
         \Slack::to('#random')->send('RANDOM');
+
+        $notification->assertSentTo(new AnonymousNotifiable(), SimpleSlack::class, 1);
+        $slackMessageSent = $notification->sent(new AnonymousNotifiable(), SimpleSlack::class)->first()->toSlack();
+        $this->assertEquals('#random', $slackMessageSent->channel);
+        $this->assertEquals('RANDOM', $slackMessageSent->content);
+    }
+
+    public function testSendMessageToAChannelWithSpecifiedWebHook()
+    {
+        $notification = Notification::fake();
+
+        \Slack::to('#random')->webhook('https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX')->send('RANDOM');
+
+        $notification->assertSentTo(new AnonymousNotifiable(), SimpleSlack::class, 1);
+        $slackMessageSent = $notification->sent(new AnonymousNotifiable(), SimpleSlack::class)->first()->toSlack();
+        $this->assertEquals('#random', $slackMessageSent->channel);
+        $this->assertEquals('RANDOM', $slackMessageSent->content);
+    }
+
+    public function testSendMessageToAUserWithSpecifiedConfig()
+    {
+        $notification = Notification::fake();
+        $config = array(
+        'slack_webhook_url' => 'https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX'
+        );
+
+        $slack = new Slack($config);
+
+        $slack->to('#random')->send('RANDOM');
 
         $notification->assertSentTo(new AnonymousNotifiable(), SimpleSlack::class, 1);
         $slackMessageSent = $notification->sent(new AnonymousNotifiable(), SimpleSlack::class)->first()->toSlack();


### PR DESCRIPTION
This feature is in response to issue #16 
User can now call webhook method on Slack class or facade to specify webhook to use to send a message. Also, removed config array from been required, since default config is also set. We simply take new config keys specified by user and use the default when not specified. Helps write shorter code that way e.g `Slack::to('#scientists')->webhook('https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/x00XXXXXXXXX')->send(':thinking_face:');`