### PR TITLE
Add support for Laravel 10 and new GitHub Action

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,44 @@
+name: run-tests
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+                php: [8.1]
+                laravel: [9.*, 10.*]
+                stability: [prefer-lowest, prefer-stable]
+                include:
+                    - laravel: 9.*
+
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+                  coverage: none
+
+            - name: Setup problem matchers
+              run: |
+                  echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+                  echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+            - name: Install dependencies
+              run: |
+                  composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+                  composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+            - name: Execute tests
+              run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 <p align="center">
 <a href="https://travis-ci.com/gpressutto5/laravel-slack"><img src="https://img.shields.io/travis/com/gpressutto5/laravel-slack/master.svg?style=for-the-badge" alt="Build Status"></a>
 <a href="https://codecov.io/gh/gpressutto5/laravel-slack"><img src="https://img.shields.io/codecov/c/github/gpressutto5/laravel-slack/master.svg?style=for-the-badge" alt="codecov"></a>
-<a href="https://scrutinizer-ci.com/g/gpressutto5/laravel-slack/"><img alt="Scrutinizer code quality" src="https://img.shields.io/scrutinizer/quality/g/gpressutto5/laravel-slack.svg?style=for-the-badge"></a>
 <a href="https://packagist.org/packages/gpressutto5/laravel-slack"><img src="https://img.shields.io/packagist/v/gpressutto5/laravel-slack.svg?style=for-the-badge" alt="Latest Stable Version"></a>
 <a href="https://packagist.org/packages/gpressutto5/laravel-slack"><img src="https://img.shields.io/packagist/php-v/gpressutto5/laravel-slack.svg?style=for-the-badge" alt="PHP from Packagist"></a>
 <a href="https://packagist.org/packages/gpressutto5/laravel-slack"><img src="https://img.shields.io/badge/laravel-%3E%3D5.5-orange.svg?style=for-the-badge" alt="Laravel Version"></a>

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": ">=7.1.3",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "illuminate/notifications": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/notifications": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
         "laravel/slack-notification-channel": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi folks!

This PR adds support for Laravel 10 and a new GitHub action to the project. With this update, users can now test their changes against the latest version of Laravel and take advantage of the new features and improvements it provides.

The new GitHub action uses a matrix to test against different combinations of PHP and Laravel versions, ensuring compatibility with a wider range of environments.

I've tested this in my fork of the project and all tests passed successfully. Please let me know if there's anything I can do to improve this PR or if you have any questions or concerns.

Thank you for your time and consideration!

Best regards,
Cristian.

---
![image](https://user-images.githubusercontent.com/8118712/231197091-9d406b9f-5901-4778-bf10-d1d5a64de132.png)
